### PR TITLE
Fixed version check to accomodate for double-digit minor version in Python version

### DIFF
--- a/slipdotpy/slip-server.py
+++ b/slipdotpy/slip-server.py
@@ -3,7 +3,7 @@
 
 import sys
 
-PY_VER = sys.version[:3].replace(".","")
+PY_VER = sys.version[:4].replace(".","")
 if int(PY_VER) < 36:
   print("You must use at least Python 3.6.x to run this App")
   print(f"Your version: {sys.version.split()[0]}")

--- a/slipdotpy/slip.py
+++ b/slipdotpy/slip.py
@@ -4,7 +4,7 @@
 #Import standard modules
 import os, sys, socket, time, sqlite3
 
-PY_VER = sys.version[:3].replace(".","")
+PY_VER = sys.version[:4].replace(".","")
 if int(PY_VER) < 36:
   print("You must use at least Python 3.6.x to run this App")
   print(f"Your version: {sys.version.split()[0]}")


### PR DESCRIPTION
For newer Python versions (>= 3.10), the initial version check fails because it only uses the first 3 characters of the Python version, effectively interpreting version 3.10 as version 3.1.

This PR extends the check to use the first 4 characters of the Python version. This will mean that the version check works as intended for versions with double-digit minor versions, and will still work as intended for single-digit minor versions as well, since the second `.` character is discarded.